### PR TITLE
Changed names again

### DIFF
--- a/BigWing-WP/ruleset.xml
+++ b/BigWing-WP/ruleset.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
-<ruleset name="BigWing-Default">
-	<description>A base ruleset that all other BigWing rulesets should extend.</description>
+<ruleset name="BigWing-WP">
+	<description>BigWing's PHP coding standards for WordPress projects.</description>
+
+	<arg name="extensions" value="php"/>
+	<!-- Show sniff codes in all reports, and progress when running -->
+	<arg value="sp"/>
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+	<!-- Enables parallel processing when available for faster results. -->
+	<arg name="parallel" value="8"/>
 
 	<exclude-pattern>*/phpunit.xml*</exclude-pattern>
 	<exclude-pattern>*/languages/*</exclude-pattern>
@@ -11,8 +19,12 @@
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
+	<!-- Production-ready files -->
+	<exclude-pattern>*/build/*</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
+
 	<!-- Ensure certain file types aren't sniffed -->
-	<exclude-pattern>*\.(css|js)</exclude-pattern>
+	<exclude-pattern>*\.(s?(a|p?c)ss|jsx?)</exclude-pattern>
 
 	<!-- Don't worry about files that don't contain any code -->
 	<rule ref="Internal.NoCodeFound">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+== dev-master ==
+
+**20200805**
+
+- Forked from 10up/phpcs-composer
+- Added rules used by BigWing for WP projects.
+- Added to Packagist as `bigwing/wp-phpcs-default`
+- Changed package to `bigwing/phpcs-composer` in preparation for non-WP rules.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 > Composer library to provide drop in installation and configuration of [WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) and [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP), setting reasonable defaults for WordPress development with nearly zero configuration.
 
-[![Support Level](https://img.shields.io/badge/support-internal-blue.svg)](#support-level) [![MIT License](https://img.shields.io/github/license/bigwing/wp-phpcs-default.svg)](https://github.com/bigwing/wp-phpcs-default/blob/master/LICENSE)
+[![Support Level](https://img.shields.io/badge/support-internal-blue.svg)](#support-level) [![MIT License](https://img.shields.io/github/license/bigwing/phpcs-composer.svg)](https://github.com/bigwing/phpcs-composer/blob/master/LICENSE)
 
 ## Installation
 
 Install the library via Composer:
 
 ```bash
-$ composer require --dev bigwing/wp-phpcs-default:dev-master
+$ composer require --dev bigwing/phpcs-composer:dev-master
 ```
 
 That's it!

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,33 @@
 {
-  "name": "bigwing/wp-phpcs-default",
+  "name": "bigwing/phpcs-composer",
   "type": "phpcodesniffer-standard",
   "version": "dev-master",
   "license": "MIT",
   "require": {
+    "php": ">=5.6.0,<8.0.0-dev",
     "squizlabs/php_codesniffer": "^3.4.0",
     "wp-coding-standards/wpcs": "^2.3",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-    "phpcompatibility/phpcompatibility-wp": "^2.1",
+    "dealerdirect/phpcodesniffer-composer-installer": "*",
+    "phpcompatibility/phpcompatibility-wp": "*",
     "roave/security-advisories": "dev-master"
   },
   "prefer-stable": true,
+  "minimum-stability": "dev",
   "authors": [
+    {
+      "name": "Morgan Estes",
+      "email": "mestes@localiq.com",
+      "homepage": "https://bigwing.com"
+    },
     {
       "name": "Ephraim Gregor",
       "email": "ephraim.gregor@10up.com"
-    },
-    {
-      "name": "Morgan Estes",
-      "email": "mestes@localiq.com"
     }
   ],
   "scripts": {
     "config-cs": [
       "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
-      "\"vendor/bin/phpcs\" --config-set default_standard BigWing-Default"
+      "\"vendor/bin/phpcs\" --config-set default_standard BigWing-WP"
     ],
     "post-install-cmd": "@config-cs",
     "post-update-cmd": "@config-cs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37a2b53813930586294894a0a09f98e3",
+    "content-hash": "9d6e7f5c3d3862083f97b8be6eb7cd53",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -626,13 +626,16 @@
     ],
     "packages-dev": [],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {
+        "php": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.6.0,<8.0.0-dev"
+    },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
Hopefully this doesn't bork Packagist too much, but this changes "Default" to "WP" in the ruleset, in preparation for non-WP rules to be added as a monolithic sniffer set.